### PR TITLE
Fix ClusterResourceQuota names that are based on User's email address

### DIFF
--- a/roles/userquota/templates/cluster_resource_quota.j2
+++ b/roles/userquota/templates/cluster_resource_quota.j2
@@ -1,7 +1,7 @@
 apiVersion: quota.openshift.io/v1
 kind: ClusterResourceQuota
 metadata:
-  name: "clusterquota-{{ item.metadata.name }}"
+  name: "clusterquota-{{ item.metadata.name | regex_replace('(.+?)@.*', '\\1') }}"
   labels:
     applied_userquota: "{{ meta.name }}"
 spec:


### PR DESCRIPTION
When the cluster is configured to authenticate users with Google OAuth, the ClusterResouceQuota cannot be created by the operator since it contains an illegal character - '@'.
This PR extracts the username part of the email address and uses it to create the ClusterResourceQuota for each user.

Signed-off-by: orenc1 <ocohen@redhat.com>