### PR TITLE
Adding Exceptions List Feature

### DIFF
--- a/deploy/crds/gpte_v1alpha1_userquota_cr.yaml
+++ b/deploy/crds/gpte_v1alpha1_userquota_cr.yaml
@@ -3,15 +3,19 @@ kind: UserQuota
 metadata:
   name: default
 spec:
-  quota:
-    hard:
-      configmaps: "10"
-      limits.cpu: "10"
-      limits.memory: 20Gi
-      persistentvolumeclaims: "20"
-      pods: "20"
-      requests.cpu: "5"
-      requests.memory: 6Gi
-      requests.storage: 50Gi
-      secrets: "150"
-      services: "30"
+  default:
+    quota:
+      hard:
+        configmaps: "10"
+        limits.cpu: "10"
+        limits.memory: 20Gi
+        persistentvolumeclaims: "20"
+        pods: "20"
+        requests.cpu: "5"
+        requests.memory: 6Gi
+        requests.storage: 50Gi
+        secrets: "150"
+        services: "30"
+  exceptions:
+    - favorite_user
+    - awesome_user

--- a/roles/userquota/tasks/main.yml
+++ b/roles/userquota/tasks/main.yml
@@ -16,7 +16,7 @@
   
 - name: Log UserQuota event
   debug:
-    msg: "UserQuota created: {{ quota }}"
+    msg: "UserQuota created: {{ default.quota }}"
 
 # Find all Users and create a ClusterResourceQuota for them
 - name: Find all users
@@ -26,9 +26,10 @@
   register:
     users
 
-- name: Create ClusterResourceQuota for Users
+- name: Create Default ClusterResourceQuota for Non-Excluded Users
   when:
     - users.resources | length > 0
+    - exceptions is not defined or item.metadata.name not in exceptions
   k8s:
     state: present
     definition: "{{ lookup('template', './templates/cluster_resource_quota.j2') }}"

--- a/roles/userquota/templates/cluster_resource_quota.j2
+++ b/roles/userquota/templates/cluster_resource_quota.j2
@@ -10,4 +10,4 @@ spec:
       openshift.io/requester: "{{ item.metadata.name }}"
     labels: null
   quota:
-    {{ quota|to_yaml }}
+    {{ default.quota|to_yaml }}


### PR DESCRIPTION
The users specified in the CR's spec.exceptions list won't have their resource quotas reconciled by the operator, thus the operator can be overriden for specific users in the cluster.

Signed-off-by: orenc1 <ocohen@redhat.com>